### PR TITLE
Add constructor to allow creating a CassandraSession from an existing CqlSession

### DIFF
--- a/src/main/scala/com/ringcentral/cassandra4io/CassandraSession.scala
+++ b/src/main/scala/com/ringcentral/cassandra4io/CassandraSession.scala
@@ -74,4 +74,15 @@ object CassandraSession {
     Resource
       .make[F, CqlSession](fromJavaAsync(builder.buildAsync()))(session => fromJavaAsync(session.closeAsync()).void)
       .map(cqlSession => new Live[F](cqlSession))
+
+  /**
+   * Create CassandraSession from an existing CqlSession.
+   * Note: the creator of the CqlSession is responsible for managing the lifecycle and this constructor is meant for interop with an existing codebase
+   *
+   * @param session is an existing CqlSession
+   * @tparam F - effect type that requires the Async capability
+   * @return CassandraSession
+   */
+  def existing[F[_]: Async](session: CqlSession): CassandraSession[F] =
+    new Live[F](session)
 }


### PR DESCRIPTION
I ran into this when migrating an existing codebase making use of the underlying CqlSession and I was incrementally migrating the code to use Cassandra4IO