### PR TITLE
Improve compositionality of ParameterizedQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Cassandra4io is currently available for Scala 2.13 and 2.12.
 
 ### Add a dependency to your project
 ```scala
-libraryDependencies += ("com.ringcentral" %% "cassandra4io" % "0.1.6")
+libraryDependencies += ("com.ringcentral" %% "cassandra4io" % "0.1.9")
 ```
 
 ### Create a connection to Cassandra
@@ -195,6 +195,28 @@ object BasicInfo {
 
 Please note that we recommend using `FromUdtValue` and `ToUdtValue` to automatically derive this hand-written (and error-prone) 
 code. 
+
+## Interpolating on CQL parameters
+
+Cassandra4IO Allows you to interpolate (i.e. using string interpolation) on values that are not valid CQL parameters using 
+`++` or `concat` to build out your CQL query. For example, you can interpolate on the keyspace and table name using 
+the `cqlConst` interpolator like so:
+
+```scala
+val session: CassandraSession[IO] = ???
+val keyspaceName = "cassandra4io"
+val tableName    = "person_attributes"
+val keyspace     = cqlConst"$keyspaceName."
+val table        = cqlConst"$tableName"
+
+def insert(data: PersonAttribute) = 
+  (cql"INSERT INTO " ++ keyspace ++ table ++ cql" (person_id, info) VALUES (${data.personId}, ${data.info})")
+    .execute(session)
+```
+
+This allows you (the author of the application) to feed in parameters like the table name and keyspace through 
+configuration. Please be aware that you should not be taking your user's input and feeding this into `cqlConst` as 
+this will pose an injection risk.
 
 ## References
 - [Datastax Java driver](https://docs.datastax.com/en/developer/java-driver/4.9)

--- a/src/it/scala/com/ringcentral/cassandra4io/cql/CqlSuite.scala
+++ b/src/it/scala/com/ringcentral/cassandra4io/cql/CqlSuite.scala
@@ -272,25 +272,24 @@ trait CqlSuite { self: IOSuite with CassandraTestsSharedInstances =>
     } yield expect(result == Seq("one"))
   }
 
-  test("cqlConst/cqlConst0 should allow you to interpolate on what is usually not possible with cql strings") {
-    session =>
-      val data         = PersonAttribute(2, BasicInfo(180.0, "tall", Set(1, 2, 3, 4, 5)))
-      val keyspaceName = "cassandra4io"
-      val tableName    = "person_attributes"
-      val selectFrom   = cql"SELECT person_id, info FROM "
-      val keyspace     = cqlConst(s"$keyspaceName.")
-      val table        = cqlConst(s"$tableName")
+  test("cqlConst allows you to interpolate on what is usually not possible with cql strings") { session =>
+    val data         = PersonAttribute(2, BasicInfo(180.0, "tall", Set(1, 2, 3, 4, 5)))
+    val keyspaceName = "cassandra4io"
+    val tableName    = "person_attributes"
+    val selectFrom   = cql"SELECT person_id, info FROM "
+    val keyspace     = cqlConst"$keyspaceName."
+    val table        = cqlConst"$tableName"
 
-      def where(personId: Int) =
-        cql" WHERE person_id = $personId"
+    def where(personId: Int) =
+      cql" WHERE person_id = $personId"
 
-      def insert(personAttribute: PersonAttribute) =
-        (cql"INSERT INTO " ++ keyspace ++ table ++ cql" (person_id, info) VALUES (${data.personId}, ${data.info})")
-          .execute(session)
+    def insert(data: PersonAttribute) =
+      (cql"INSERT INTO " ++ keyspace ++ table ++ cql" (person_id, info) VALUES (${data.personId}, ${data.info})")
+        .execute(session)
 
-      for {
-        _      <- insert(data)
-        result <- (selectFrom ++ keyspace ++ table ++ where(data.personId)).as[PersonAttribute].selectFirst(session)
-      } yield expect(result.isDefined && result.get == data)
+    for {
+      _      <- insert(data)
+      result <- (selectFrom ++ keyspace ++ table ++ where(data.personId)).as[PersonAttribute].selectFirst(session)
+    } yield expect(result.isDefined && result.get == data)
   }
 }

--- a/src/it/scala/com/ringcentral/cassandra4io/cql/CqlSuite.scala
+++ b/src/it/scala/com/ringcentral/cassandra4io/cql/CqlSuite.scala
@@ -278,14 +278,14 @@ trait CqlSuite { self: IOSuite with CassandraTestsSharedInstances =>
       val keyspaceName = "cassandra4io"
       val tableName    = "person_attributes"
       val selectFrom   = cql"SELECT person_id, info FROM "
-      val keyspace     = cqlConst0(s"$keyspaceName.")
+      val keyspace     = cqlConst(s"$keyspaceName.")
       val table        = cqlConst(s"$tableName")
 
       def where(personId: Int) =
-        cql"WHERE person_id = $personId"
+        cql" WHERE person_id = $personId"
 
       def insert(personAttribute: PersonAttribute) =
-        (cql"INSERT INTO " ++ keyspace ++ table ++ cql"(person_id, info) VALUES (${data.personId}, ${data.info})")
+        (cql"INSERT INTO " ++ keyspace ++ table ++ cql" (person_id, info) VALUES (${data.personId}, ${data.info})")
           .execute(session)
 
       for {

--- a/src/main/scala/com/ringcentral/cassandra4io/CassandraSession.scala
+++ b/src/main/scala/com/ringcentral/cassandra4io/CassandraSession.scala
@@ -74,4 +74,15 @@ object CassandraSession {
     Resource
       .make[F, CqlSession](fromJavaAsync(builder.buildAsync()))(session => fromJavaAsync(session.closeAsync()).void)
       .map(cqlSession => new Live[F](cqlSession))
+
+  /**
+   * Create CassandraSession from an existing CqlSession.
+   * Note: the creator of the CqlSession is responsible for managing the lifecycle and this constructor is meant for interop with an existing codebase
+   *
+   * @param session is an existing CqlSession
+   * @tparam F - effect type that requires the Async capability
+   * @return CassandraSession
+   */
+  def existing[F[_]: Async](session: CqlSession): CassandraSession[F] =
+    new Live[F](session)
 }

--- a/src/main/scala/com/ringcentral/cassandra4io/cql/package.scala
+++ b/src/main/scala/com/ringcentral/cassandra4io/cql/package.scala
@@ -157,19 +157,21 @@ package object cql {
       ParameterizedQuery[V, Row](QueryTemplate[V, Row](ctx.parts.mkString("?"), identity), values)
   }
 
-  implicit class CqlStringContext(ctx: StringContext) {
-    val cqlt = new CqlTemplateStringInterpolator(ctx)
-    val cql  = new CqlStringInterpolator(ctx)
-  }
-
   /**
    * Provides a way to lift arbitrary strings into CQL so you can parameterize on values that are not valid CQL parameters
    * Please note that this is not escaped so do not use this with user-supplied input for your application (only use
    * cqlConst for input that you as the application author control)
-   * @param str
-   * @return
    */
-  def cqlConst(str: String): ParameterizedQuery[HNil, Row] = ParameterizedQuery(QueryTemplate(str, identity), HNil)
+  class CqlConstInterpolator(ctx: StringContext) {
+    def apply(args: Any*): ParameterizedQuery[HNil, Row] =
+      ParameterizedQuery(QueryTemplate(ctx.s(args: _*), identity), HNil)
+  }
+
+  implicit class CqlStringContext(ctx: StringContext) {
+    val cqlt     = new CqlTemplateStringInterpolator(ctx)
+    val cql      = new CqlStringInterpolator(ctx)
+    val cqlConst = new CqlConstInterpolator(ctx)
+  }
 
   @implicitNotFound("""Cannot find or construct a Binder instance for type:
 

--- a/src/main/scala/com/ringcentral/cassandra4io/cql/package.scala
+++ b/src/main/scala/com/ringcentral/cassandra4io/cql/package.scala
@@ -163,23 +163,13 @@ package object cql {
   }
 
   /**
-   * Provides a way to lift arbitrary strings into SQL so you can parameterize on values that are not valid CQL parameters
-   * This variant inserts whitespace after to minimize adding whitespaces when composing. Please note that this is not
-   * escaped so do not use this with user-supplied input for your application.
-   *
+   * Provides a way to lift arbitrary strings into CQL so you can parameterize on values that are not valid CQL parameters
+   * Please note that this is not escaped so do not use this with user-supplied input for your application (only use
+   * cqlConst for input that you as the application author control)
    * @param str
    * @return
    */
-  def cqlConst(str: String): ParameterizedQuery[HNil, Row] = ParameterizedQuery(QueryTemplate(s"$str ", identity), HNil)
-
-  /**
-   * Provides a way to lift arbitrary strings into SQL so you can parameterize on values that are not valid CQL parameters
-   * This variant does not insert whitespace. Please note that this is not escaped so do not use this with user-supplied
-   * input for your application.
-   * @param str
-   * @return
-   */
-  def cqlConst0(str: String): ParameterizedQuery[HNil, Row] = ParameterizedQuery(QueryTemplate(str, identity), HNil)
+  def cqlConst(str: String): ParameterizedQuery[HNil, Row] = ParameterizedQuery(QueryTemplate(str, identity), HNil)
 
   @implicitNotFound("""Cannot find or construct a Binder instance for type:
 


### PR DESCRIPTION
We have a use case at work where we need to feed in the keyspace/table via configuration. In order to do this, I need to be able to interpolate on CQL parameters like table name/etc. (very similar to Doobie's Fragment). I have gone ahead and added this capability to `ParameterizedQuery` and kept track of all the types at the value level and the type level thanks to Shapeless' `Prepend` typeclass. The resulting syntax allows for queries and insertions like this to be formulated:

```scala
val session: CassandraSession[IO] = ??? 

val data         = PersonAttribute(2, BasicInfo(180.0, "tall", Set(1, 2, 3, 4, 5)))
val keyspaceName = "cassandra4io"
val tableName    = "person_attributes"
val selectFrom   = cql"SELECT person_id, info FROM "
val keyspace     = cqlConst0(s"$keyspaceName.")
val table        = cqlConst(s"$tableName")

def where(personId: Int) =
  cql"WHERE person_id = $personId"

def insert(personAttribute: PersonAttribute) =
  (cql"INSERT INTO " ++ keyspace ++ table ++ cql"(person_id, info) VALUES (${data.personId}, ${data.info})")
    .execute(session)
```

Please let me know what what you guys think and please feel free to suggest any improvements 🙇🏽 

Thank you!