### PR TITLE
Improve compile-time efficiency of the non-parameterized query

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ lazy val root = (project in file("."))
       "com.disneystreaming" %% "weaver-cats"                    % "0.7.6"  % "it,test",
       "org.testcontainers"   % "testcontainers"                 % "1.16.3" % "it",
       "com.dimafeng"        %% "testcontainers-scala-cassandra" % "0.40.0" % "it",
-      "ch.qos.logback"       % "logback-classic"                % "1.2.10"
+      "ch.qos.logback"       % "logback-classic"                % "1.2.10" % "it,test"
     ) ++ (scalaBinaryVersion.value match {
       case v if v.startsWith("2.13") =>
         Seq.empty

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ inThisBuild(
     organizationName := "ringcentral",
     licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
     scalaVersion := crossScalaVersions.value.head,
-    crossScalaVersions := Seq("2.13.6", "2.12.12"),
+    crossScalaVersions := Seq("2.13.8", "2.12.15"),
     licenses := Seq(("Apache-2.0", url("https://opensource.org/licenses/Apache-2.0"))),
     homepage := Some(url("https://github.com/ringcentral/cassandra4io")),
     developers := List(
@@ -26,21 +26,24 @@ lazy val root = (project in file("."))
   .settings(
     Defaults.itSettings,
     libraryDependencies ++= Seq(
-      "org.typelevel"       %% "cats-effect"                    % "3.2.9",
-      "co.fs2"              %% "fs2-core"                       % "3.1.3",
+      "org.typelevel"       %% "cats-effect"                    % "3.3.5",
+      "co.fs2"              %% "fs2-core"                       % "3.2.4",
       "com.datastax.oss"     % "java-driver-core"               % "4.13.0",
       "com.chuusai"         %% "shapeless"                      % "2.3.7"
     ) ++ Seq(
       "com.disneystreaming" %% "weaver-cats"                    % "0.7.6"  % "it,test",
-      "org.testcontainers"   % "testcontainers"                 % "1.15.3" % "it",
-      "com.dimafeng"        %% "testcontainers-scala-cassandra" % "0.39.8" % "it",
-      "ch.qos.logback"       % "logback-classic"                % "1.2.6"  % "it,test"
+      "org.testcontainers"   % "testcontainers"                 % "1.16.3" % "it",
+      "com.dimafeng"        %% "testcontainers-scala-cassandra" % "0.40.0" % "it",
+      "ch.qos.logback"       % "logback-classic"                % "1.2.10"
     ) ++ (scalaBinaryVersion.value match {
       case v if v.startsWith("2.13") =>
         Seq.empty
+
       case v if v.startsWith("2.12") =>
-        Seq("org.scala-lang.modules" %% "scala-collection-compat" % "2.3.2")
-      case other                     => sys.error(s"Unsupported scala version: $other")
+        Seq("org.scala-lang.modules" %% "scala-collection-compat" % "2.6.0")
+
+      case other                     =>
+        sys.error(s"Unsupported scala version: $other")
     })
   )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.6.1

--- a/src/it/scala/com/ringcentral/cassandra4io/CassandraTestsSharedInstances.scala
+++ b/src/it/scala/com/ringcentral/cassandra4io/CassandraTestsSharedInstances.scala
@@ -16,7 +16,7 @@ import scala.io.BufferedSource
 trait CassandraTestsSharedInstances { self: IOSuite =>
 
   val keyspace  = "cassandra4io"
-  val container = CassandraContainer(DockerImageName.parse("cassandra:3.11.8"))
+  val container = CassandraContainer(DockerImageName.parse("cassandra:3.11.11"))
 
   def migrateSession(session: CassandraSession[IO]): IO[Unit] = {
     val migrationSource = IO.blocking(scala.io.Source.fromResource("migration/1__test_tables.cql"))


### PR DESCRIPTION
Uses a similar technique to Doobie `sql` interpolator and Cats Show `show` interpolator to avoid requiring Binder of HList which was causing the issue in the first place. Special thanks to @phderome for showing me how to properly use the interpolator and @nbenns for pairing with me.

Closes https://github.com/ringcentral/cassandra4io/issues/21