### PR TITLE
Using unset instead of setToNull for Binder[Option[T]]

### DIFF
--- a/src/main/scala/com/ringcentral/cassandra4io/cql/package.scala
+++ b/src/main/scala/com/ringcentral/cassandra4io/cql/package.scala
@@ -310,7 +310,7 @@ package object cql {
     implicit def optionBinder[T: Binder]: Binder[Option[T]] = new Binder[Option[T]] {
       override def bind(statement: BoundStatement, index: Int, value: Option[T]): (BoundStatement, Int) = value match {
         case Some(x) => Binder[T].bind(statement, index, x)
-        case None    => (statement.setToNull(index), index + 1)
+        case None    => (statement.unset(index), index + 1)
       }
     }
 


### PR DESCRIPTION
Previously `Binder[Option[T]]` used `statement.setToNull` to set up null values in prepared statements. But it leads to a tombstone write. With `statement.unset` instead no tombstone will be written. And getting rid of some extra tombstones is always a good thing in Cassandra.