### PR TITLE
Fixing option encoding through unset

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,17 @@ object Dao {
 } 
 ```
 
+### Handling optional fields (`null`)
+
+By default, cassandra4io encodes `Option` as a `null` value. Which is ok for most cases. But in Cassandra, there is a difference between a `null` value and an empty value. In java driver this difference is represented by `BoundStatement#setToNull` (default behavior) and `BoundStatement#unset` (setting an empty field). The main advantage of using `unset` instead of `setToNull` is that tombstone will not be created for an empty field.
+
+To use the `unset` instead of the `setToNull` for your optional value in a `cql` interpolators you could add `.usingUnset` to your optional value. Like in the following example:
+```scala
+import com.ringcentral.cassandra4io.cql._
+
+cql"insert into entities(foo, bar, baz) values (${e.foo}, ${e.bar}, ${e.baz.usingUnset}"
+```
+
 ## User Defined Type (UDT) support
 
 Cassandra4IO provides support for Cassandra's User Defined Type (UDT) values. 

--- a/src/it/scala/com/ringcentral/cassandra4io/cql/CqlSuite.scala
+++ b/src/it/scala/com/ringcentral/cassandra4io/cql/CqlSuite.scala
@@ -7,7 +7,7 @@ import com.ringcentral.cassandra4io.CassandraTestsSharedInstances
 import fs2.Stream
 import weaver._
 
-import java.time.{ Duration, LocalDate, LocalTime }
+import java.time.{Duration, LocalDate, LocalTime}
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -390,6 +390,48 @@ trait CqlSuite {
     for {
       result <- cql"select id, data FROM cassandra4io.test_data WHERE id = 0".as[Data].selectFirst(session).attempt
     } yield expect(result.isLeft) && expect(getError(result).isInstanceOf[UnexpectedNullValue])
+  }
+
+  test("nullable field should be correctly encoded in inserts") { session =>
+    val id = 5L
+    val data: Option[String] = None
+    for {
+      result <- cql"insert into cassandra4io.test_data (id, data) values ($id, $data)".execute(session).attempt
+    } yield expect(result.isRight) && expect(result.contains(true))
+  }
+
+  test("nullable field should be correctly encoded in updates' where condition") { session =>
+    val value: Option[Int] = None
+    for {
+      result <- cql"update cassandra4io.test_data set count = 30 where id = $value".execute(session).attempt
+    } yield expect(result.isRight) && expect(result.contains(true))
+  }
+
+  test("nullable fields should be correctly set with 'usingUnset'") { session =>
+    case class TestData(id: Long, data: Option[String], count: Option[Int])
+    val id = 111L
+    val data1 = TestData(id, Some("test"), Some(15))
+    val data2 = TestData(id, None, None)
+
+    // This test looks a bit awkward.
+    // It's because there is no easy way to differentiate between a null and empty field.
+    for {
+      insertResult1 <-
+        cql"insert into cassandra4io.test_data (id, data, count) values (${data1.id}, ${data1.data}, ${data1.count})"
+          .execute(session).attempt
+      selectResult1 <-
+        cql"select id, data, count from cassandra4io.test_data where id = $id".as[TestData].selectFirst(session)
+      insertResult2 <-
+        cql"insert into cassandra4io.test_data (id, data, count) values (${data2.id}, ${data2.data}, ${data2.count.usingUnset})"
+        .execute(session).attempt
+      selectResult2 <-
+        cql"select id, data, count from cassandra4io.test_data where id = $id".as[TestData].selectFirst(session)
+    } yield {
+      expect(insertResult1.contains(true)) &&
+        expect(insertResult2.contains(true)) &&
+        expect(selectResult1.contains(data1)) &&
+        expect(selectResult2.contains(data2.copy(count = data1.count)))
+    }
   }
 
   // handle NULL values for udt columns

--- a/src/it/scala/com/ringcentral/cassandra4io/cql/CqlSuite.scala
+++ b/src/it/scala/com/ringcentral/cassandra4io/cql/CqlSuite.scala
@@ -400,13 +400,6 @@ trait CqlSuite {
     } yield expect(result.isRight) && expect(result.contains(true))
   }
 
-  test("nullable field should be correctly encoded in updates' where condition") { session =>
-    val value: Option[Int] = None
-    for {
-      result <- cql"update cassandra4io.test_data set count = 30 where id = $value".execute(session).attempt
-    } yield expect(result.isRight) && expect(result.contains(true))
-  }
-
   test("nullable fields should be correctly set with 'usingUnset'") { session =>
     case class TestData(id: Long, data: Option[String], count: Option[Int])
     val id = 111L

--- a/src/main/scala/com/ringcentral/cassandra4io/cql/package.scala
+++ b/src/main/scala/com/ringcentral/cassandra4io/cql/package.scala
@@ -220,7 +220,7 @@ package object cql {
     def cqlConst = new CqlConstInterpolator(ctx)
   }
 
-  implicit class UnsetOptionValueOps[A](self: Option[A]) {
+  implicit class UnsetOptionValueOps[A](val self: Option[A]) extends AnyVal {
     def usingUnset(implicit aBinder: Binder[A]): BoundValue[Option[A]] =
       BoundValue(self, Binder.optionUsingUnsetBinder[A])
   }


### PR DESCRIPTION
Continuing of my [previous pull request](https://github.com/ringcentral/cassandra4io/pull/24) about `unset`.

I practically revert my previous change: by default `Option` binder will again use `setToNull`. To use `unset` an `usingUnset` extension method should be explicitly called inside an interpolator string. 

What else have done:
* `BoundValue` is now public. Without this `usingUnset` will not work.
* More tests about `null` and `usingUnset`.
* Docs update.
* Small additional improvement: `CqlStringContext` is now `AnyVal`. To get rid of extra allocations.