### PR TITLE
Latest version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Cassandra4io is currently available for Scala 2.13 and 2.12.
 
 ### Add a dependency to your project
 ```scala
-libraryDependencies += ("com.ringcentral" %% "cassandra4io" % "0.1.13")
+libraryDependencies += ("com.ringcentral" %% "cassandra4io" % "0.1.14")
 ```
 
 ### Create a connection to Cassandra

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Cassandra 4 io
 
 ![CI](https://github.com/ringcentral/cassandra4io/workflows/CI/badge.svg?branch=main)
+![Maven Central](https://img.shields.io/maven-central/v/com.ringcentral/cassandra4io_2.13)
 
 This is lightweight cats-effect and fs2 IO wrapper for latest datastax 4.x driver.
 


### PR DESCRIPTION
Hi guys!

Recently I decided to play around with Cassandra and use your wrapper. I ran into a discrepancy between the latest released version and the one described in the `README.md`. I wanted to make a pull-request for an update, but I looked at the history that this had already [happened recently](https://github.com/ringcentral/cassandra4io/pull/25).

My proposal is to automate this thing through a clickable maven badge:
* No need to edit the version by hand with a new release (looks like the latest version will be automatically fetched and showed)
* Maven page has tutorials on how to add a dependency in different build tools, so no need for `Add a dependency to your project` paragraph