### PR TITLE
Added Columns, Values, KeyEqualsTo and Assignment types for cqlt interpolator

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "3.7.14"
+version = "2.7.5"
 maxColumn = 120
 align = most
 continuationIndent.defnSite = 2

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ object Dao {
   def apply[F[_] : Async](session: CassandraSession[F]) = for {
     insert <- insertQuery.prepare(session)
     update <- updateQuery.prepare(session)
-    updateAlternative <- insertQueryAlternative.prepare(session)
+    insertAlternative <- insertQueryAlternative.prepare(session)
     select <- selectQuery.prepare(session)
   } yield new Dao[F] {
     override def put(value: Model) = insert(
@@ -123,7 +123,7 @@ object Dao {
       value.ck,
       value.data,
       value.metaData
-    ).execute.void // updateAlternative(value).execute.void
+    ).execute.void // insertAlternative(value).execute.void
     override def update(key: Key, data: Data): F[Unit] = updateQuery(data, key).execute.void
     override def get(key: Key) = select(key).config(_.setExecutionProfileName("default")).select.head.compile.last
   }

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ object Dao {
       value.metaData
     ).execute.void // updateAlternative(value).execute.void
     override def update(key: Key, data: Data): F[Unit] = updateQuery(data, key).execute.void
-    override def get(key: Key) = select(id).config(_.setExecutionProfileName("default")).select.head.compile.last
+    override def get(key: Key) = select(key).config(_.setExecutionProfileName("default")).select.head.compile.last
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ object Dao {
   }
 }
 ```
-As you can see `${Columns[Model]}` expands to `pk, ck, data, meta_data`, `${Values[Model]}` to `?, ?, ?, ?`, `${Assignment[Data]}` to `pk = ?, ck = ?, data = ?, meta_data = ?` and `${EqualsTo[Key]}` expands to `pk = ? and ck = ? and data = ? and meta_data = ?`.
+As you can see `${Columns[Model]}` expands to `pk, ck, data, meta_data`, `${Values[Model]}` to `?, ?, ?, ?`, `${Assignment[Data]}` to `data = ?, meta_data = ?` and `${EqualsTo[Key]}` expands to `pk = ? and ck = ?`.
 Latter three types adjust query type as well for being able to bind corresponding values 
 
 ### Handling optional fields (`null`)

--- a/src/it/resources/migration/1__test_tables.cql
+++ b/src/it/resources/migration/1__test_tables.cql
@@ -74,3 +74,12 @@ CREATE TABLE heavily_nested_prim_table(
     data example_nested_primitive_type,
     PRIMARY KEY (id)
 );
+
+create table test_data_interpolated(
+    key bigint,
+    projectionKey text,
+    projectionData text,
+    offset bigint,
+    timestamp bigint,
+    PRIMARY KEY (key, projectionKey)
+);

--- a/src/it/resources/migration/1__test_tables.cql
+++ b/src/it/resources/migration/1__test_tables.cql
@@ -77,9 +77,9 @@ CREATE TABLE heavily_nested_prim_table(
 
 create table test_data_interpolated(
     key bigint,
-    projectionKey text,
-    projectionData text,
+    projection_key text,
+    projection_data text,
     offset bigint,
     timestamp bigint,
-    PRIMARY KEY (key, projectionKey)
+    PRIMARY KEY (key, projection_key)
 );

--- a/src/it/scala/com/ringcentral/cassandra4io/cql/CqlSuite.scala
+++ b/src/it/scala/com/ringcentral/cassandra4io/cql/CqlSuite.scala
@@ -202,7 +202,7 @@ trait CqlSuite {
 
     val insert = cqlt"INSERT INTO ${Const("test_data_interpolated")}(${Columns[Table]}) VALUES (${Values[Table]})"
     val select =
-      cqlt"SELECT ${Columns[Table]} FROM ${Const("test_data_interpolated")} WHERE ${KeyEquals[Key]}"
+      cqlt"SELECT ${Columns[Table]} FROM ${Const("test_data_interpolated")} WHERE ${KeyEqualsTo[Key]}"
         .as[Table]
 
     val data1 = Table(1, "projection-1", "data-1", 1, 1732547921580L)
@@ -224,9 +224,9 @@ trait CqlSuite {
     case class Data(projectionData: String, offset: Long, timestamp: Long)
     case class Key(key: Long, projectionKey: String)
 
-    val update = cqlt"UPDATE ${Const("test_data_interpolated")} SET ${Assignment[Data]} WHERE ${KeyEquals[Key]}"
+    val update = cqlt"UPDATE ${Const("test_data_interpolated")} SET ${Assignment[Data]} WHERE ${KeyEqualsTo[Key]}"
     val select =
-      cqlt"SELECT ${Columns[Data]} FROM ${Const("test_data_interpolated")} WHERE ${KeyEquals[Key]}"
+      cqlt"SELECT ${Columns[Data]} FROM ${Const("test_data_interpolated")} WHERE ${KeyEqualsTo[Key]}"
         .as[Data]
 
     val data1 = Data("data-1", 1, 1732547921580L)

--- a/src/it/scala/com/ringcentral/cassandra4io/cql/CqlSuite.scala
+++ b/src/it/scala/com/ringcentral/cassandra4io/cql/CqlSuite.scala
@@ -7,7 +7,7 @@ import com.ringcentral.cassandra4io.CassandraTestsSharedInstances
 import fs2.Stream
 import weaver._
 
-import java.time.{Duration, LocalDate, LocalTime}
+import java.time.{ Duration, LocalDate, LocalTime }
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -202,7 +202,7 @@ trait CqlSuite {
 
     val insert = cqlt"INSERT INTO ${Const("test_data_interpolated")}(${Columns[Table]}) VALUES (${Values[Table]})"
     val select =
-      cqlt"SELECT ${Columns[Table]} FROM ${Const("test_data_interpolated")} WHERE ${KeyEqualsTo[Key]}"
+      cqlt"SELECT ${Columns[Table]} FROM ${Const("test_data_interpolated")} WHERE ${EqualsTo[Key]}"
         .as[Table]
 
     val data1 = Table(1, "projection-1", "data-1", 1, 1732547921580L)
@@ -224,9 +224,9 @@ trait CqlSuite {
     case class Data(projectionData: String, offset: Long, timestamp: Long)
     case class Key(key: Long, projectionKey: String)
 
-    val update = cqlt"UPDATE ${Const("test_data_interpolated")} SET ${Assignment[Data]} WHERE ${KeyEqualsTo[Key]}"
+    val update = cqlt"UPDATE ${Const("test_data_interpolated")} SET ${Assignment[Data]} WHERE ${EqualsTo[Key]}"
     val select =
-      cqlt"SELECT ${Columns[Data]} FROM ${Const("test_data_interpolated")} WHERE ${KeyEqualsTo[Key]}"
+      cqlt"SELECT ${Columns[Data]} FROM ${Const("test_data_interpolated")} WHERE ${EqualsTo[Key]}"
         .as[Data]
 
     val data1 = Data("data-1", 1, 1732547921580L)

--- a/src/main/scala/com/ringcentral/cassandra4io/cql/package.scala
+++ b/src/main/scala/com/ringcentral/cassandra4io/cql/package.scala
@@ -325,8 +325,8 @@ package object cql {
     }
   }
 
-  trait ColumnsValues[T] extends Columns[T] with Values[T]
-  object ColumnsValues {
+  private trait ColumnsValues[T] extends Columns[T] with Values[T]
+  private object ColumnsValues {
     def apply[T](implicit ev: ColumnsValues[T]): ColumnsValues[T] = ev
 
     implicit val hNilColumnsValues: ColumnsValues[HNil] = new ColumnsValues[HNil] {

--- a/src/main/scala/com/ringcentral/cassandra4io/cql/package.scala
+++ b/src/main/scala/com/ringcentral/cassandra4io/cql/package.scala
@@ -184,31 +184,9 @@ package object cql {
           override def binder: Binder[RT] = f.binder
         }
 
-      implicit def hConsBindableValuesBuilder[T: ColumnsValues, PT <: HList, RT <: HList](implicit
+      implicit def hConsBindableValuesBuilder[V[_] <: Values[_], T: ColumnsValues, PT <: HList, RT <: HList](implicit
         f: BindableBuilder.Aux[PT, RT]
-      ): BindableBuilder.Aux[Values[T] :: PT, T :: RT] = new BindableBuilder[Values[T] :: PT] {
-        override type Repr = T :: RT
-        override def binder: Binder[T :: RT] = {
-          implicit val hBinder: Binder[T]  = Values[T].binder
-          implicit val tBinder: Binder[RT] = f.binder
-          Binder[T :: RT]
-        }
-      }
-
-      implicit def hConsBindableRestrictionsBuilder[T: ColumnsValues, PT <: HList, RT <: HList](implicit
-        f: BindableBuilder.Aux[PT, RT]
-      ): BindableBuilder.Aux[KeyEqualsTo[T] :: PT, T :: RT] = new BindableBuilder[KeyEqualsTo[T] :: PT] {
-        override type Repr = T :: RT
-        override def binder: Binder[T :: RT] = {
-          implicit val hBinder: Binder[T]  = Values[T].binder
-          implicit val tBinder: Binder[RT] = f.binder
-          Binder[T :: RT]
-        }
-      }
-
-      implicit def hConsBindableAssignmentsBuilder[T: ColumnsValues, PT <: HList, RT <: HList](implicit
-        f: BindableBuilder.Aux[PT, RT]
-      ): BindableBuilder.Aux[Assignment[T] :: PT, T :: RT] = new BindableBuilder[Assignment[T] :: PT] {
+      ): BindableBuilder.Aux[V[T] :: PT, T :: RT] = new BindableBuilder[V[T] :: PT] {
         override type Repr = T :: RT
         override def binder: Binder[T :: RT] = {
           implicit val hBinder: Binder[T]  = Values[T].binder

--- a/src/main/scala/com/ringcentral/cassandra4io/cql/package.scala
+++ b/src/main/scala/com/ringcentral/cassandra4io/cql/package.scala
@@ -127,7 +127,7 @@ package object cql {
         ctx.parts
           .foldLeft[(HList, StringBuilder)]((params, new StringBuilder())) {
             case ((Const(const) :: tail, builder), part)                => (tail, builder.appendAll(part).appendAll(const))
-            case (((restriction: KeyEquals[_]) :: tail, builder), part) =>
+            case (((restriction: KeyEqualsTo[_]) :: tail, builder), part) =>
               (tail, builder.appendAll(part).appendAll(restriction.keys.map(key => s"${key} = ?").mkString(" AND ")))
             case (((assignment: Assignment[_]) :: tail, builder), part) =>
               (tail, builder.appendAll(part).appendAll(assignment.keys.map(key => s"${key} = ?").mkString(", ")))
@@ -197,7 +197,7 @@ package object cql {
 
       implicit def hConsBindableRestrictionsBuilder[T: ColumnsValues, PT <: HList, RT <: HList](implicit
         f: BindableBuilder.Aux[PT, RT]
-      ): BindableBuilder.Aux[KeyEquals[T] :: PT, T :: RT] = new BindableBuilder[KeyEquals[T] :: PT] {
+      ): BindableBuilder.Aux[KeyEqualsTo[T] :: PT, T :: RT] = new BindableBuilder[KeyEqualsTo[T] :: PT] {
         override type Repr = T :: RT
         override def binder: Binder[T :: RT] = {
           implicit val hBinder: Binder[T]  = Values[T].binder
@@ -329,9 +329,9 @@ package object cql {
       override def binder: Binder[T] = ColumnsValues[T].binder
     }
   }
-  trait KeyEquals[T] extends Columns[T] with Values[T]
-  object KeyEquals {
-    def apply[T: ColumnsValues]: KeyEquals[T] = new KeyEquals[T] {
+  trait KeyEqualsTo[T] extends Columns[T] with Values[T]
+  object KeyEqualsTo {
+    def apply[T: ColumnsValues]: KeyEqualsTo[T] = new KeyEqualsTo[T] {
       override def keys: List[String] = ColumnsValues[T].keys
       override def size: Int          = ColumnsValues[T].size
       override def binder: Binder[T]  = ColumnsValues[T].binder

--- a/src/main/scala/com/ringcentral/cassandra4io/cql/package.scala
+++ b/src/main/scala/com/ringcentral/cassandra4io/cql/package.scala
@@ -126,17 +126,17 @@ package object cql {
       QueryTemplate[V, Row](
         ctx.parts
           .foldLeft[(HList, StringBuilder)]((params, new StringBuilder())) {
-            case ((Const(const) :: tail, builder), part)                => (tail, builder.appendAll(part).appendAll(const))
+            case ((Const(const) :: tail, builder), part)                  => (tail, builder.appendAll(part).appendAll(const))
             case (((restriction: KeyEqualsTo[_]) :: tail, builder), part) =>
               (tail, builder.appendAll(part).appendAll(restriction.keys.map(key => s"${key} = ?").mkString(" AND ")))
-            case (((assignment: Assignment[_]) :: tail, builder), part) =>
+            case (((assignment: Assignment[_]) :: tail, builder), part)   =>
               (tail, builder.appendAll(part).appendAll(assignment.keys.map(key => s"${key} = ?").mkString(", ")))
-            case (((columns: Columns[_]) :: tail, builder), part)       =>
+            case (((columns: Columns[_]) :: tail, builder), part)         =>
               (tail, builder.appendAll(part).appendAll(columns.keys.mkString(", ")))
-            case (((values: Values[_]) :: tail, builder), part)         =>
+            case (((values: Values[_]) :: tail, builder), part)           =>
               (tail, builder.appendAll(part).appendAll(List.fill(values.size)("?").mkString(", ")))
-            case ((_ :: tail, builder), part)                           => (tail, builder.appendAll(part).appendAll("?"))
-            case ((HNil, builder), part)                                => (HNil, builder.appendAll(part))
+            case ((_ :: tail, builder), part)                             => (tail, builder.appendAll(part).appendAll("?"))
+            case ((HNil, builder), part)                                  => (HNil, builder.appendAll(part))
           }
           ._2
           .toString(),
@@ -311,19 +311,19 @@ package object cql {
   }
 
   case class Const(fragment: String)
-  trait Columns[T] {
+  trait Columns[T]   {
     def keys: List[String]
   }
-  object Columns   {
+  object Columns     {
     def apply[T: ColumnsValues]: Columns[T] = new Columns[T] {
       override def keys: List[String] = ColumnsValues[T].keys
     }
   }
-  trait Values[T]  {
+  trait Values[T]    {
     def size: Int
     def binder: Binder[T]
   }
-  object Values    {
+  object Values      {
     def apply[T: ColumnsValues]: Values[T] = new Values[T] {
       override def size: Int         = ColumnsValues[T].size
       override def binder: Binder[T] = ColumnsValues[T].binder

--- a/src/main/scala/com/ringcentral/cassandra4io/cql/package.scala
+++ b/src/main/scala/com/ringcentral/cassandra4io/cql/package.scala
@@ -335,6 +335,12 @@ package object cql {
       override def binder: Binder[HNil] = Binder.hNilBinder
     }
 
+    private def camel2snake(text: String) =
+      text.tail.foldLeft(text.headOption.fold("")(_.toLower.toString)) {
+        case (acc, c) if c.isUpper => acc + "_" + c.toLower
+        case (acc, c)              => acc + c
+      }
+
     implicit def hListColumnsValues[K, V, T <: HList](implicit
       witness: Witness.Aux[K],
       tColumnsValues: ColumnsValues[T],
@@ -343,7 +349,7 @@ package object cql {
       new ColumnsValues[FieldType[K, V] :: T] {
         override def keys: List[String] = {
           val key = witness.value match {
-            case Symbol(key) => key
+            case Symbol(key) => camel2snake(key)
             case _           => witness.value.toString
           }
           key :: tColumnsValues.keys

--- a/src/main/scala/com/ringcentral/cassandra4io/cql/package.scala
+++ b/src/main/scala/com/ringcentral/cassandra4io/cql/package.scala
@@ -126,17 +126,17 @@ package object cql {
       QueryTemplate[V, Row](
         ctx.parts
           .foldLeft[(HList, StringBuilder)]((params, new StringBuilder())) {
-            case ((Const(const) :: tail, builder), part)                  => (tail, builder.appendAll(part).appendAll(const))
-            case (((restriction: KeyEqualsTo[_]) :: tail, builder), part) =>
+            case ((Const(const) :: tail, builder), part)                => (tail, builder.appendAll(part).appendAll(const))
+            case (((restriction: EqualsTo[_]) :: tail, builder), part)  =>
               (tail, builder.appendAll(part).appendAll(restriction.keys.map(key => s"${key} = ?").mkString(" AND ")))
-            case (((assignment: Assignment[_]) :: tail, builder), part)   =>
+            case (((assignment: Assignment[_]) :: tail, builder), part) =>
               (tail, builder.appendAll(part).appendAll(assignment.keys.map(key => s"${key} = ?").mkString(", ")))
-            case (((columns: Columns[_]) :: tail, builder), part)         =>
+            case (((columns: Columns[_]) :: tail, builder), part)       =>
               (tail, builder.appendAll(part).appendAll(columns.keys.mkString(", ")))
-            case (((values: Values[_]) :: tail, builder), part)           =>
+            case (((values: Values[_]) :: tail, builder), part)         =>
               (tail, builder.appendAll(part).appendAll(List.fill(values.size)("?").mkString(", ")))
-            case ((_ :: tail, builder), part)                             => (tail, builder.appendAll(part).appendAll("?"))
-            case ((HNil, builder), part)                                  => (HNil, builder.appendAll(part))
+            case ((_ :: tail, builder), part)                           => (tail, builder.appendAll(part).appendAll("?"))
+            case ((HNil, builder), part)                                => (HNil, builder.appendAll(part))
           }
           ._2
           .toString(),
@@ -289,27 +289,27 @@ package object cql {
   }
 
   case class Const(fragment: String)
-  trait Columns[T]   {
+  trait Columns[T] {
     def keys: List[String]
   }
-  object Columns     {
+  object Columns   {
     def apply[T: ColumnsValues]: Columns[T] = new Columns[T] {
       override def keys: List[String] = ColumnsValues[T].keys
     }
   }
-  trait Values[T]    {
+  trait Values[T]  {
     def size: Int
     def binder: Binder[T]
   }
-  object Values      {
+  object Values    {
     def apply[T: ColumnsValues]: Values[T] = new Values[T] {
       override def size: Int         = ColumnsValues[T].size
       override def binder: Binder[T] = ColumnsValues[T].binder
     }
   }
-  trait KeyEqualsTo[T] extends Columns[T] with Values[T]
-  object KeyEqualsTo {
-    def apply[T: ColumnsValues]: KeyEqualsTo[T] = new KeyEqualsTo[T] {
+  trait EqualsTo[T] extends Columns[T] with Values[T]
+  object EqualsTo  {
+    def apply[T: ColumnsValues]: EqualsTo[T] = new EqualsTo[T] {
       override def keys: List[String] = ColumnsValues[T].keys
       override def size: Int          = ColumnsValues[T].size
       override def binder: Binder[T]  = ColumnsValues[T].binder


### PR DESCRIPTION
Slightly extended cqlt interpolator syntax:
- `Columns[T]` useful when listing columns being selected from (or inserted into) table
- `Values[T]` useful when binding values during inserts
- `EqualsTo[T]` useful when filtering result set by some key
- `Assignment[T]` useful when binding values during updates